### PR TITLE
test: Add E2E SLL testing 

### DIFF
--- a/src/proposals/20250403/SparkEthereum_20250403.t.sol
+++ b/src/proposals/20250403/SparkEthereum_20250403.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.10;
 
-import { console } from "forge-std/console.sol";
-
 import 'src/test-harness/SparkTestBase.sol';
 
 import { IERC20 }   from 'forge-std/interfaces/IERC20.sol';
@@ -125,13 +123,12 @@ contract SparkEthereum_20250403Test is SparkTestBase {
 
         deployPayloads();
 
-        console.log("SETUP");
-
         //chainSpellMetadata[ChainIdUtils.ArbitrumOne()].payload = 0x8839aC188064542331D4E7f6112aab7b71ac706F;
         //chainSpellMetadata[ChainIdUtils.Base()].payload        = 0xf3e842AFe529e4E241B4aE15033163E3F4C46ce0;
         //chainSpellMetadata[ChainIdUtils.Ethereum()].payload    = ;
     }
 
+    // Overriding because of upgrade
     function _getLatestControllers() internal pure override returns (address, address, address) {
         return (
             ETHEREUM_NEW_ALM_CONTROLLER,

--- a/src/proposals/20250403/SparkEthereum_20250403.t.sol
+++ b/src/proposals/20250403/SparkEthereum_20250403.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.10;
 
+import { console } from "forge-std/console.sol";
+
 import 'src/test-harness/SparkTestBase.sol';
 
 import { IERC20 }   from 'forge-std/interfaces/IERC20.sol';
@@ -79,7 +81,7 @@ contract SparkEthereum_20250403Test is SparkTestBase {
 
     address internal constant ETHEREUM_OLD_ALM_CONTROLLER = Ethereum.ALM_CONTROLLER;
     address internal constant ETHEREUM_NEW_ALM_CONTROLLER = 0xF51164FE5B0DC7aFB9192E1b806ae18A8813Ae8c;
-    
+
     address internal constant BASE_OLD_ALM_CONTROLLER     = Base.ALM_CONTROLLER;
     address internal constant BASE_NEW_ALM_CONTROLLER     = 0xB94378b5347a3E199AF3575719F67A708a5D8b9B;
 
@@ -120,12 +122,22 @@ contract SparkEthereum_20250403Test is SparkTestBase {
             gnosisForkBlock:      38037888,  // Not used
             arbitrumOneForkBlock: 320078656
         });
-        
+
         deployPayloads();
+
+        console.log("SETUP");
 
         //chainSpellMetadata[ChainIdUtils.ArbitrumOne()].payload = 0x8839aC188064542331D4E7f6112aab7b71ac706F;
         //chainSpellMetadata[ChainIdUtils.Base()].payload        = 0xf3e842AFe529e4E241B4aE15033163E3F4C46ce0;
         //chainSpellMetadata[ChainIdUtils.Ethereum()].payload    = ;
+    }
+
+    function _getLatestControllers() internal pure override returns (address, address, address) {
+        return (
+            ETHEREUM_NEW_ALM_CONTROLLER,
+            ARBITRUM_NEW_ALM_CONTROLLER,
+            BASE_NEW_ALM_CONTROLLER
+        );
     }
 
     function test_ETHEREUM_controllerUpgrade() public onChain(ChainIdUtils.Ethereum()) {
@@ -273,7 +285,7 @@ contract SparkEthereum_20250403Test is SparkTestBase {
 
     function test_ETHEREUM_centrifugeJTRSYOnboarding() public onChain(ChainIdUtils.Ethereum()) {
         SparkLiquidityLayerContext memory ctx = _getSparkLiquidityLayerContext();
-        
+
         MainnetController controller = MainnetController(ETHEREUM_NEW_ALM_CONTROLLER);
 
         bytes32 depositKey = RateLimitHelpers.makeAssetKey(
@@ -383,7 +395,7 @@ contract SparkEthereum_20250403Test is SparkTestBase {
         uint256 depositSlope          = 5_000_000e6 / uint256(1 days);
         IERC20 usdc                   = IERC20(Ethereum.USDC);
         IMapleTokenExtended syrup     = IMapleTokenExtended(vault);
-        
+
         // Slightly modify code from _testERC4626Onboarding due to async redemption
         SparkLiquidityLayerContext memory ctx = _getSparkLiquidityLayerContext();
         bytes32 depositKey = RateLimitHelpers.makeAssetKey(
@@ -437,7 +449,7 @@ contract SparkEthereum_20250403Test is SparkTestBase {
 
         assertEq(usdc.balanceOf(address(ctx.proxy)),  0);
         assertApproxEqAbs(syrup.balanceOf(address(ctx.proxy)), shares / 2, 1);
-        
+
         IWithdrawalManagerLike withdrawManager = IPoolManagerLike(syrup.manager()).withdrawalManager();
         vm.prank(IPoolManagerLike(syrup.manager()).poolDelegate());
         withdrawManager.processRedemptions(shares / 2);
@@ -468,7 +480,7 @@ contract SparkEthereum_20250403Test is SparkTestBase {
     function test_ETHEREUM_sllCoreRateLimitIncrease() public onChain(ChainIdUtils.Ethereum()) {
         bytes32 usdsMintKey       = MainnetController(ETHEREUM_NEW_ALM_CONTROLLER).LIMIT_USDS_MINT();
         bytes32 swapUSDSToUSDCKey = MainnetController(ETHEREUM_NEW_ALM_CONTROLLER).LIMIT_USDS_TO_USDC();
-        
+
         _assertRateLimit(usdsMintKey,       50_000_000e18, 50_000_000e18 / uint256(1 days));
         _assertRateLimit(swapUSDSToUSDCKey, 50_000_000e6,  50_000_000e6 / uint256(1 days));
 

--- a/src/proposals/20250403/SparkEthereum_20250403.t.sol
+++ b/src/proposals/20250403/SparkEthereum_20250403.t.sol
@@ -115,10 +115,10 @@ contract SparkEthereum_20250403Test is SparkTestBase {
     function setUp() public {
         // March 28, 2025
         setupDomains({
-            mainnetForkBlock:     22169117,
-            baseForkBlock:        28330800,
+            mainnetForkBlock:     22176878,
+            baseForkBlock:        28377597,
             gnosisForkBlock:      38037888,  // Not used
-            arbitrumOneForkBlock: 321564756
+            arbitrumOneForkBlock: 321939172
         });
 
         chainSpellMetadata[ChainIdUtils.ArbitrumOne()].payload = 0x545eeEc8Ca599085cE86ada51eb8c0c35Af1e9d6;

--- a/src/proposals/20250403/SparkEthereum_20250403.t.sol
+++ b/src/proposals/20250403/SparkEthereum_20250403.t.sol
@@ -115,7 +115,7 @@ contract SparkEthereum_20250403Test is SparkTestBase {
     function setUp() public {
         // March 28, 2025
         setupDomains({
-            mainnetForkBlock:     22176878,
+            mainnetForkBlock:     22177076,
             baseForkBlock:        28377597,
             gnosisForkBlock:      38037888,  // Not used
             arbitrumOneForkBlock: 321939172

--- a/src/proposals/20250403/SparkEthereum_20250403.t.sol
+++ b/src/proposals/20250403/SparkEthereum_20250403.t.sol
@@ -115,11 +115,13 @@ contract SparkEthereum_20250403Test is SparkTestBase {
     function setUp() public {
         // March 28, 2025
         setupDomains({
-            mainnetForkBlock:     22177076,
-            baseForkBlock:        28377597,
+            mainnetForkBlock:     22169117,
+            baseForkBlock:        28374079,
             gnosisForkBlock:      38037888,  // Not used
-            arbitrumOneForkBlock: 321939172
+            arbitrumOneForkBlock: 321564756
         });
+
+        deployPayloads();
 
         chainSpellMetadata[ChainIdUtils.ArbitrumOne()].payload = 0x545eeEc8Ca599085cE86ada51eb8c0c35Af1e9d6;
         chainSpellMetadata[ChainIdUtils.Base()].payload        = 0x43d32D791C35D34d28fa8c33cfB8ca3c6AE0d02d;

--- a/src/test-harness/SparkLiquidityLayerTests.sol
+++ b/src/test-harness/SparkLiquidityLayerTests.sol
@@ -341,50 +341,62 @@ abstract contract SparkLiquidityLayerTests is SpellRunner {
 
         assertEq(arbUsdc.balanceOf(Arbitrum.ALM_PROXY), arbUsdcProxyBalance);
 
-        _relayMessageOverBridges();
+        console.log("\n--- In test");
+        console.log("arb num bridges ", chainSpellMetadata[ChainIdUtils.ArbitrumOne()].bridges.length);
+        console.log("base num bridges", chainSpellMetadata[ChainIdUtils.Base()].bridges.length);
+        console.log("arb bridge 0    ", uint256(chainSpellMetadata[ChainIdUtils.ArbitrumOne()].bridgeTypes[0]));
+        console.log("base bridge 0   ", uint256(chainSpellMetadata[ChainIdUtils.Base()].bridgeTypes[0]));
+        console.log("base bridge 1   ", uint256(chainSpellMetadata[ChainIdUtils.Base()].bridgeTypes[1]));
 
-        assertEq(arbUsdc.balanceOf(Arbitrum.ALM_PROXY), arbUsdcProxyBalance + usdcAmount);
-        assertEq(arbUsdc.balanceOf(Arbitrum.PSM3),      arbUsdcPsmBalance);
+        // TODO: Figure out Array out of bounds error,
+        CCTPBridgeTesting.relayMessagesToDestination(
+            chainSpellMetadata[ChainIdUtils.ArbitrumOne()].bridges[1], true
+        );
 
-        // --- Step 2: Deposit 10m USDC into PSM3 ---
+        // _relayMessageOverBridges();
 
-        vm.prank(Arbitrum.ALM_RELAYER);
-        arbController.depositPSM(Arbitrum.USDC, usdcAmount);
+        // assertEq(arbUsdc.balanceOf(Arbitrum.ALM_PROXY), arbUsdcProxyBalance + usdcAmount);
+        // assertEq(arbUsdc.balanceOf(Arbitrum.PSM3),      arbUsdcPsmBalance);
 
-        assertEq(arbUsdc.balanceOf(Arbitrum.ALM_PROXY), arbUsdcProxyBalance);
-        assertEq(arbUsdc.balanceOf(Arbitrum.PSM3),      arbUsdcPsmBalance + usdcAmount);
+        // // --- Step 2: Deposit 10m USDC into PSM3 ---
 
-        // --- Step 3: Withdraw all assets from PSM3 ---
+        // vm.prank(Arbitrum.ALM_RELAYER);
+        // arbController.depositPSM(Arbitrum.USDC, usdcAmount);
 
-        vm.prank(Arbitrum.ALM_RELAYER);
-        arbController.withdrawPSM(Arbitrum.USDC, usdcAmount);
+        // assertEq(arbUsdc.balanceOf(Arbitrum.ALM_PROXY), arbUsdcProxyBalance);
+        // assertEq(arbUsdc.balanceOf(Arbitrum.PSM3),      arbUsdcPsmBalance + usdcAmount);
 
-        assertEq(arbUsdc.balanceOf(Arbitrum.ALM_PROXY), arbUsdcProxyBalance + usdcAmount);
-        assertEq(arbUsdc.balanceOf(Arbitrum.PSM3),      arbUsdcPsmBalance);
+        // // --- Step 3: Withdraw all assets from PSM3 ---
 
-        // --- Step 4: Bridge USDC back to mainnet
+        // vm.prank(Arbitrum.ALM_RELAYER);
+        // arbController.withdrawPSM(Arbitrum.USDC, usdcAmount);
 
-        vm.prank(Arbitrum.ALM_RELAYER);
-        arbController.transferUSDCToCCTP(usdcAmount, CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM);
+        // assertEq(arbUsdc.balanceOf(Arbitrum.ALM_PROXY), arbUsdcProxyBalance + usdcAmount);
+        // assertEq(arbUsdc.balanceOf(Arbitrum.PSM3),      arbUsdcPsmBalance);
 
-        assertEq(arbUsdc.balanceOf(Arbitrum.ALM_PROXY), arbUsdcProxyBalance);
+        // // --- Step 4: Bridge USDC back to mainnet
 
-        chainSpellMetadata[ChainIdUtils.Ethereum()].domain.selectFork();
+        // vm.prank(Arbitrum.ALM_RELAYER);
+        // arbController.transferUSDCToCCTP(usdcAmount, CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM);
 
-        assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
+        // assertEq(arbUsdc.balanceOf(Arbitrum.ALM_PROXY), arbUsdcProxyBalance);
 
-        _relayMessageOverBridges();
+        // chainSpellMetadata[ChainIdUtils.Ethereum()].domain.selectFork();
 
-        assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance + usdcAmount);
+        // assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
 
-        // --- Step 5: Swap USDC to USDS and burn ---
+        // _relayMessageOverBridges();
 
-        vm.startPrank(Ethereum.ALM_RELAYER);
-        mainnetController.swapUSDCToUSDS(usdcAmount);
-        mainnetController.burnUSDS(usdcAmount * 1e12);
-        vm.stopPrank();
+        // assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance + usdcAmount);
 
-        assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
+        // // --- Step 5: Swap USDC to USDS and burn ---
+
+        // vm.startPrank(Ethereum.ALM_RELAYER);
+        // mainnetController.swapUSDCToUSDS(usdcAmount);
+        // mainnetController.burnUSDS(usdcAmount * 1e12);
+        // vm.stopPrank();
+
+        // assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
     }
 
     function _testE2ESparkLiquidityLayerBase(
@@ -417,50 +429,60 @@ abstract contract SparkLiquidityLayerTests is SpellRunner {
 
         assertEq(baseUsdc.balanceOf(Base.ALM_PROXY), baseUsdcProxyBalance);
 
-        _relayMessageOverBridges();
+        console.log("\n--- In test");
+        console.log("arb num bridges ", chainSpellMetadata[ChainIdUtils.ArbitrumOne()].bridges.length);
+        console.log("base num bridges", chainSpellMetadata[ChainIdUtils.Base()].bridges.length);
+        console.log("arb bridge 0    ", uint256(chainSpellMetadata[ChainIdUtils.ArbitrumOne()].bridgeTypes[0]));
+        console.log("arb bridge 1    ", uint256(chainSpellMetadata[ChainIdUtils.ArbitrumOne()].bridgeTypes[1]));
+        console.log("base bridge 0   ", uint256(chainSpellMetadata[ChainIdUtils.Base()].bridgeTypes[0]));
 
-        assertEq(baseUsdc.balanceOf(Base.ALM_PROXY), baseUsdcProxyBalance + usdcAmount);
-        assertEq(baseUsdc.balanceOf(Base.PSM3),      baseUsdcPsmBalance);
+        // _relayMessageOverBridges();
+        // CCTPBridgeTesting.relayMessagesToDestination(
+        //     chainSpellMetadata[ChainIdUtils.Base()].bridges[1], true
+        // );
 
-        // --- Step 3: Deposit USDC into PSM3 ---
+        // assertEq(baseUsdc.balanceOf(Base.ALM_PROXY), baseUsdcProxyBalance + usdcAmount);
+        // assertEq(baseUsdc.balanceOf(Base.PSM3),      baseUsdcPsmBalance);
 
-        vm.prank(Base.ALM_RELAYER);
-        baseController.depositPSM(Base.USDC, usdcAmount);
+        // // --- Step 3: Deposit USDC into PSM3 ---
 
-        assertEq(baseUsdc.balanceOf(Base.ALM_PROXY), baseUsdcProxyBalance);
-        assertEq(baseUsdc.balanceOf(Base.PSM3),      baseUsdcPsmBalance + usdcAmount);
+        // vm.prank(Base.ALM_RELAYER);
+        // baseController.depositPSM(Base.USDC, usdcAmount);
 
-        // --- Step 4: Withdraw all assets from PSM3 ---
+        // assertEq(baseUsdc.balanceOf(Base.ALM_PROXY), baseUsdcProxyBalance);
+        // assertEq(baseUsdc.balanceOf(Base.PSM3),      baseUsdcPsmBalance + usdcAmount);
 
-        vm.prank(Base.ALM_RELAYER);
-        baseController.withdrawPSM(Base.USDC, usdcAmount);
+        // // --- Step 4: Withdraw all assets from PSM3 ---
 
-        assertEq(baseUsdc.balanceOf(Base.ALM_PROXY), baseUsdcProxyBalance + usdcAmount);
-        assertEq(baseUsdc.balanceOf(Base.PSM3),      baseUsdcPsmBalance);
+        // vm.prank(Base.ALM_RELAYER);
+        // baseController.withdrawPSM(Base.USDC, usdcAmount);
 
-        // --- Step 5: Bridge USDC back to mainnet ---
+        // assertEq(baseUsdc.balanceOf(Base.ALM_PROXY), baseUsdcProxyBalance + usdcAmount);
+        // assertEq(baseUsdc.balanceOf(Base.PSM3),      baseUsdcPsmBalance);
 
-        vm.prank(Base.ALM_RELAYER);
-        baseController.transferUSDCToCCTP(usdcAmount, CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM);
+        // // --- Step 5: Bridge USDC back to mainnet ---
 
-        assertEq(baseUsdc.balanceOf(Base.ALM_PROXY), baseUsdcProxyBalance);
+        // vm.prank(Base.ALM_RELAYER);
+        // baseController.transferUSDCToCCTP(usdcAmount, CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM);
 
-        chainSpellMetadata[ChainIdUtils.Ethereum()].domain.selectFork();
+        // assertEq(baseUsdc.balanceOf(Base.ALM_PROXY), baseUsdcProxyBalance);
 
-        assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
+        // chainSpellMetadata[ChainIdUtils.Ethereum()].domain.selectFork();
 
-        _relayMessageOverBridges();
+        // assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
 
-        assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance + usdcAmount);
+        // _relayMessageOverBridges();
 
-        // --- Step 6: Swap USDC to USDS and burn ---
+        // assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance + usdcAmount);
 
-        vm.startPrank(Ethereum.ALM_RELAYER);
-        mainnetController.swapUSDCToUSDS(usdcAmount);
-        mainnetController.burnUSDS(usdcAmount * 1e12);
-        vm.stopPrank();
+        // // --- Step 6: Swap USDC to USDS and burn ---
 
-        assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
+        // vm.startPrank(Ethereum.ALM_RELAYER);
+        // mainnetController.swapUSDCToUSDS(usdcAmount);
+        // mainnetController.burnUSDS(usdcAmount * 1e12);
+        // vm.stopPrank();
+
+        // assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
     }
 
     function _testE2ESLLCrossChainForDomain(
@@ -598,39 +620,39 @@ abstract contract SparkLiquidityLayerTests is SpellRunner {
         // );
     }
 
-    function test_E2E_sparkLiquidityLayerCrossChainSetup2() public{
-        // _testE2ESLLCrossChainForDomain(
-        //     ChainIdUtils.ArbitrumOne(),
-        //     MainnetController(Ethereum.ALM_CONTROLLER),
-        //     ForeignController(Arbitrum.ALM_CONTROLLER)
-        // );
+    // function test_E2E_sparkLiquidityLayerCrossChainSetup2() public{
+    //     // _testE2ESLLCrossChainForDomain(
+    //     //     ChainIdUtils.ArbitrumOne(),
+    //     //     MainnetController(Ethereum.ALM_CONTROLLER),
+    //     //     ForeignController(Arbitrum.ALM_CONTROLLER)
+    //     // );
 
-        _testE2ESLLCrossChainForDomain(
-            ChainIdUtils.Base(),
-            MainnetController(Ethereum.ALM_CONTROLLER),
-            ForeignController(Base.ALM_CONTROLLER)
-        );
+    //     _testE2ESLLCrossChainForDomain(
+    //         ChainIdUtils.Base(),
+    //         MainnetController(Ethereum.ALM_CONTROLLER),
+    //         ForeignController(Base.ALM_CONTROLLER)
+    //     );
 
-        // executeAllPayloadsAndBridges();
+    //     // executeAllPayloadsAndBridges();
 
-        // // Load the latest controllers (will return the same values if not overridden)
-        // (
-        //     address updatedMainnetController,
-        //     address updatedArbController,
-        //     address updatedBaseController
-        // ) = _getLatestControllers();
+    //     // // Load the latest controllers (will return the same values if not overridden)
+    //     // (
+    //     //     address updatedMainnetController,
+    //     //     address updatedArbController,
+    //     //     address updatedBaseController
+    //     // ) = _getLatestControllers();
 
-        // _testE2ESLLCrossChainForDomain(
-        //     ChainIdUtils.ArbitrumOne(),
-        //     MainnetController(updatedMainnetController),
-        //     ForeignController(updatedArbController)
-        // );
+    //     // _testE2ESLLCrossChainForDomain(
+    //     //     ChainIdUtils.ArbitrumOne(),
+    //     //     MainnetController(updatedMainnetController),
+    //     //     ForeignController(updatedArbController)
+    //     // );
 
-        // _testE2ESLLCrossChainForDomain(
-        //     ChainIdUtils.Base(),
-        //     MainnetController(updatedMainnetController),
-        //     ForeignController(updatedBaseController)
-        // );
-    }
+    //     // _testE2ESLLCrossChainForDomain(
+    //     //     ChainIdUtils.Base(),
+    //     //     MainnetController(updatedMainnetController),
+    //     //     ForeignController(updatedBaseController)
+    //     // );
+    // }
 
 }

--- a/src/test-harness/SparkLiquidityLayerTests.sol
+++ b/src/test-harness/SparkLiquidityLayerTests.sol
@@ -16,6 +16,7 @@ import { RateLimitHelpers }  from "spark-alm-controller/src/RateLimitHelpers.sol
 
 import { IAToken } from 'sparklend-v1-core/contracts/interfaces/IAToken.sol';
 
+import { CCTPBridgeTesting }     from "xchain-helpers/testing/bridges/CCTPBridgeTesting.sol";
 import { CCTPForwarder }         from 'xchain-helpers/forwarders/CCTPForwarder.sol';
 import { Domain, DomainHelpers } from "xchain-helpers/testing/Domain.sol";
 
@@ -339,8 +340,12 @@ abstract contract SparkLiquidityLayerTests is SpellRunner {
         assertEq(arbUsdc.balanceOf(Arbitrum.ALM_PROXY), 0);
         assertEq(arbUsdc.balanceOf(Arbitrum.PSM3),      arbUsdcPsmBalance);
 
-        _relayMessageOverBridges();
-        // _clearLogs();
+        // _relayMessageOverBridges();
+
+        CCTPBridgeTesting.relayMessagesToDestination(
+            chainSpellMetadata[ChainIdUtils.ArbitrumOne()].bridges[1],
+            true
+        );
 
         assertEq(arbUsdc.balanceOf(Arbitrum.ALM_PROXY), usdcAmount);
         assertEq(arbUsdc.balanceOf(Arbitrum.PSM3),      arbUsdcPsmBalance);
@@ -372,7 +377,12 @@ abstract contract SparkLiquidityLayerTests is SpellRunner {
 
         assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), usdcAlmProxyBalance);
 
-        _relayMessageOverBridges();
+        // _relayMessageOverBridges();
+
+        CCTPBridgeTesting.relayMessagesToSource(
+            chainSpellMetadata[ChainIdUtils.ArbitrumOne()].bridges[1],
+            true
+        );
 
         // assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), usdcAlmProxyBalance + usdcAmount);
 

--- a/src/test-harness/SparkLiquidityLayerTests.sol
+++ b/src/test-harness/SparkLiquidityLayerTests.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.0;
 
-import { console } from "forge-std/console.sol";
-
 import { IERC20 }   from "forge-std/interfaces/IERC20.sol";
 import { IERC4626 } from "forge-std/interfaces/IERC4626.sol";
 
@@ -29,8 +27,8 @@ import { SLLHelpers }            from '../libraries/SLLHelpers.sol';
 import { SpellRunner } from "./SpellRunner.sol";
 
 interface IPSMLike {
-    function shares(address account) external view returns (uint256);
     function convertToAssetValue(uint256 shares) external view returns (uint256);
+    function shares(address account) external view returns (uint256);
 }
 
 struct SparkLiquidityLayerContext {

--- a/src/test-harness/SparkLiquidityLayerTests.sol
+++ b/src/test-harness/SparkLiquidityLayerTests.sol
@@ -463,39 +463,174 @@ abstract contract SparkLiquidityLayerTests is SpellRunner {
         assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
     }
 
+    function _testE2ESLLCrossChainForDomain(
+        ChainId           domainId,
+        MainnetController mainnetController,
+        ForeignController foreignController
+    )
+        internal onChain(ChainIdUtils.Ethereum())
+    {
+        IERC20  domainUsdc;
+        address domainPsm3;
+        uint32  domainCctpId;
+
+        if (domainId == ChainIdUtils.ArbitrumOne()) {
+            domainUsdc   = IERC20(Arbitrum.USDC);
+            domainPsm3   = Arbitrum.PSM3;
+            domainCctpId = CCTPForwarder.DOMAIN_ID_CIRCLE_ARBITRUM_ONE;
+        } else if (domainId == ChainIdUtils.Base()) {
+            domainUsdc   = IERC20(Base.USDC);
+            domainPsm3   = Base.PSM3;
+            domainCctpId = CCTPForwarder.DOMAIN_ID_CIRCLE_BASE;
+        } else {
+            revert("SLL/unknown domain");
+        }
+
+        IERC20 usdc = IERC20(Ethereum.USDC);
+
+        uint256 mainnetUsdcProxyBalance = usdc.balanceOf(Ethereum.ALM_PROXY);
+
+        // --- Step 1: Mint and bridge 1m USDC to Base ---
+
+        uint256 usdcAmount = 1_000_000e6;
+
+        vm.startPrank(Ethereum.ALM_RELAYER);
+        mainnetController.mintUSDS(usdcAmount * 1e12);
+        mainnetController.swapUSDSToUSDC(usdcAmount);
+        mainnetController.transferUSDCToCCTP(usdcAmount, domainCctpId);
+        vm.stopPrank();
+
+        assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
+
+        chainSpellMetadata[domainId].domain.selectFork();
+
+        SparkLiquidityLayerContext memory ctx = _getSparkLiquidityLayerContext();
+
+        // NOTE: Using param here because during an upgrade the _sparkLiquidityLayerContext
+        //       will return a controller that is out of date.
+        ForeignController domainController = ForeignController(foreignController);
+
+        address domainAlmProxy = address(ctx.proxy);
+
+        uint256 domainUsdcProxyBalance = domainUsdc.balanceOf(domainAlmProxy);
+        uint256 domainUsdcPsmBalance   = domainUsdc.balanceOf(domainPsm3);
+
+        assertEq(domainUsdc.balanceOf(domainAlmProxy), domainUsdcProxyBalance);
+
+        _relayMessageOverBridges();
+
+        assertEq(domainUsdc.balanceOf(domainAlmProxy), domainUsdcProxyBalance + usdcAmount);
+        // assertEq(domainUsdc.balanceOf(domainPsm3),     domainUsdcPsmBalance);
+
+        // // --- Step 3: Deposit USDC into PSM3 ---
+
+        // vm.prank(ctx.relayer);
+        // domainController.depositPSM(address(domainUsdc), usdcAmount);
+
+        // assertEq(domainUsdc.balanceOf(domainAlmProxy), domainUsdcProxyBalance);
+        // assertEq(domainUsdc.balanceOf(domainPsm3),     domainUsdcPsmBalance + usdcAmount);
+
+        // // --- Step 4: Withdraw all assets from PSM3 ---
+
+        // vm.prank(ctx.relayer);
+        // domainController.withdrawPSM(address(domainUsdc), usdcAmount);
+
+        // assertEq(domainUsdc.balanceOf(domainAlmProxy), domainUsdcProxyBalance + usdcAmount);
+        // assertEq(domainUsdc.balanceOf(domainPsm3),     domainUsdcPsmBalance);
+
+        // // --- Step 5: Bridge USDC back to mainnet ---
+
+        // vm.prank(ctx.relayer);
+        // domainController.transferUSDCToCCTP(usdcAmount, CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM);
+
+        // assertEq(domainUsdc.balanceOf(domainAlmProxy), domainUsdcProxyBalance);
+
+        // chainSpellMetadata[ChainIdUtils.Ethereum()].domain.selectFork();
+
+        // assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
+
+        // _relayMessageOverBridges();
+
+        // assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance + usdcAmount);
+
+        // // --- Step 6: Swap USDC to USDS and burn ---
+
+        // vm.startPrank(Ethereum.ALM_RELAYER);
+        // mainnetController.swapUSDCToUSDS(usdcAmount);
+        // mainnetController.burnUSDS(usdcAmount * 1e12);
+        // vm.stopPrank();
+
+        // assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
+    }
+
     /**********************************************************************************************/
     /*** E2E tests to be run on every spell                                                     ***/
     /**********************************************************************************************/
 
     function test_E2E_sparkLiquidityLayerCrossChainSetup() public{
-        _testE2ESparkLiquidityLayerArbitrum(
-            MainnetController(Ethereum.ALM_CONTROLLER),
-            ForeignController(Arbitrum.ALM_CONTROLLER)
-        );
+        // _testE2ESparkLiquidityLayerArbitrum(
+        //     MainnetController(Ethereum.ALM_CONTROLLER),
+        //     ForeignController(Arbitrum.ALM_CONTROLLER)
+        // );
 
         _testE2ESparkLiquidityLayerBase(
             MainnetController(Ethereum.ALM_CONTROLLER),
             ForeignController(Base.ALM_CONTROLLER)
         );
 
-        executeAllPayloadsAndBridges();
+        // executeAllPayloadsAndBridges();
 
-        // Load the latest controllers (will return the same values if not overridden)
-        (
-            address updatedMainnetController,
-            address updatedArbController,
-            address updatedBaseController
-        ) = _getLatestControllers();
+        // // Load the latest controllers (will return the same values if not overridden)
+        // (
+        //     address updatedMainnetController,
+        //     address updatedArbController,
+        //     address updatedBaseController
+        // ) = _getLatestControllers();
 
-        _testE2ESparkLiquidityLayerArbitrum(
-            MainnetController(updatedMainnetController),
-            ForeignController(updatedArbController)
+        // _testE2ESparkLiquidityLayerArbitrum(
+        //     MainnetController(updatedMainnetController),
+        //     ForeignController(updatedArbController)
+        // );
+
+        // _testE2ESparkLiquidityLayerBase(
+        //     MainnetController(updatedMainnetController),
+        //     ForeignController(updatedBaseController)
+        // );
+    }
+
+    function test_E2E_sparkLiquidityLayerCrossChainSetup2() public{
+        // _testE2ESLLCrossChainForDomain(
+        //     ChainIdUtils.ArbitrumOne(),
+        //     MainnetController(Ethereum.ALM_CONTROLLER),
+        //     ForeignController(Arbitrum.ALM_CONTROLLER)
+        // );
+
+        _testE2ESLLCrossChainForDomain(
+            ChainIdUtils.Base(),
+            MainnetController(Ethereum.ALM_CONTROLLER),
+            ForeignController(Base.ALM_CONTROLLER)
         );
 
-        _testE2ESparkLiquidityLayerBase(
-            MainnetController(updatedMainnetController),
-            ForeignController(updatedBaseController)
-        );
+        // executeAllPayloadsAndBridges();
+
+        // // Load the latest controllers (will return the same values if not overridden)
+        // (
+        //     address updatedMainnetController,
+        //     address updatedArbController,
+        //     address updatedBaseController
+        // ) = _getLatestControllers();
+
+        // _testE2ESLLCrossChainForDomain(
+        //     ChainIdUtils.ArbitrumOne(),
+        //     MainnetController(updatedMainnetController),
+        //     ForeignController(updatedArbController)
+        // );
+
+        // _testE2ESLLCrossChainForDomain(
+        //     ChainIdUtils.Base(),
+        //     MainnetController(updatedMainnetController),
+        //     ForeignController(updatedBaseController)
+        // );
     }
 
 }

--- a/src/test-harness/SparkLiquidityLayerTests.sol
+++ b/src/test-harness/SparkLiquidityLayerTests.sol
@@ -16,7 +16,6 @@ import { RateLimitHelpers }  from "spark-alm-controller/src/RateLimitHelpers.sol
 
 import { IAToken } from 'sparklend-v1-core/contracts/interfaces/IAToken.sol';
 
-import { CCTPBridgeTesting }     from "xchain-helpers/testing/bridges/CCTPBridgeTesting.sol";
 import { CCTPForwarder }         from 'xchain-helpers/forwarders/CCTPForwarder.sol';
 import { Domain, DomainHelpers } from "xchain-helpers/testing/Domain.sol";
 
@@ -25,11 +24,6 @@ import { ChainIdUtils, ChainId } from "../libraries/ChainId.sol";
 import { SLLHelpers }            from '../libraries/SLLHelpers.sol';
 
 import { SpellRunner } from "./SpellRunner.sol";
-
-interface IPSMLike {
-    function convertToAssetValue(uint256 shares) external view returns (uint256);
-    function shares(address account) external view returns (uint256);
-}
 
 struct SparkLiquidityLayerContext {
     address     controller;

--- a/src/test-harness/SparkLiquidityLayerTests.sol
+++ b/src/test-harness/SparkLiquidityLayerTests.sol
@@ -348,55 +348,55 @@ abstract contract SparkLiquidityLayerTests is SpellRunner {
         console.log("base bridge 0   ", uint256(chainSpellMetadata[ChainIdUtils.Base()].bridgeTypes[0]));
         console.log("base bridge 1   ", uint256(chainSpellMetadata[ChainIdUtils.Base()].bridgeTypes[1]));
 
-        // TODO: Figure out Array out of bounds error,
-        CCTPBridgeTesting.relayMessagesToDestination(
-            chainSpellMetadata[ChainIdUtils.ArbitrumOne()].bridges[1], true
-        );
+        // // TODO: Figure out Array out of bounds error,
+        // CCTPBridgeTesting.relayMessagesToDestination(
+        //     chainSpellMetadata[ChainIdUtils.ArbitrumOne()].bridges[1], true
+        // );
 
-        // _relayMessageOverBridges();
+        _relayMessageOverBridges();
 
-        // assertEq(arbUsdc.balanceOf(Arbitrum.ALM_PROXY), arbUsdcProxyBalance + usdcAmount);
-        // assertEq(arbUsdc.balanceOf(Arbitrum.PSM3),      arbUsdcPsmBalance);
+        assertEq(arbUsdc.balanceOf(Arbitrum.ALM_PROXY), arbUsdcProxyBalance + usdcAmount);
+        assertEq(arbUsdc.balanceOf(Arbitrum.PSM3),      arbUsdcPsmBalance);
 
-        // // --- Step 2: Deposit 10m USDC into PSM3 ---
+        // --- Step 2: Deposit 10m USDC into PSM3 ---
 
-        // vm.prank(Arbitrum.ALM_RELAYER);
-        // arbController.depositPSM(Arbitrum.USDC, usdcAmount);
+        vm.prank(Arbitrum.ALM_RELAYER);
+        arbController.depositPSM(Arbitrum.USDC, usdcAmount);
 
-        // assertEq(arbUsdc.balanceOf(Arbitrum.ALM_PROXY), arbUsdcProxyBalance);
-        // assertEq(arbUsdc.balanceOf(Arbitrum.PSM3),      arbUsdcPsmBalance + usdcAmount);
+        assertEq(arbUsdc.balanceOf(Arbitrum.ALM_PROXY), arbUsdcProxyBalance);
+        assertEq(arbUsdc.balanceOf(Arbitrum.PSM3),      arbUsdcPsmBalance + usdcAmount);
 
-        // // --- Step 3: Withdraw all assets from PSM3 ---
+        // --- Step 3: Withdraw all assets from PSM3 ---
 
-        // vm.prank(Arbitrum.ALM_RELAYER);
-        // arbController.withdrawPSM(Arbitrum.USDC, usdcAmount);
+        vm.prank(Arbitrum.ALM_RELAYER);
+        arbController.withdrawPSM(Arbitrum.USDC, usdcAmount);
 
-        // assertEq(arbUsdc.balanceOf(Arbitrum.ALM_PROXY), arbUsdcProxyBalance + usdcAmount);
-        // assertEq(arbUsdc.balanceOf(Arbitrum.PSM3),      arbUsdcPsmBalance);
+        assertEq(arbUsdc.balanceOf(Arbitrum.ALM_PROXY), arbUsdcProxyBalance + usdcAmount);
+        assertEq(arbUsdc.balanceOf(Arbitrum.PSM3),      arbUsdcPsmBalance);
 
-        // // --- Step 4: Bridge USDC back to mainnet
+        // --- Step 4: Bridge USDC back to mainnet
 
-        // vm.prank(Arbitrum.ALM_RELAYER);
-        // arbController.transferUSDCToCCTP(usdcAmount, CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM);
+        vm.prank(Arbitrum.ALM_RELAYER);
+        arbController.transferUSDCToCCTP(usdcAmount, CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM);
 
-        // assertEq(arbUsdc.balanceOf(Arbitrum.ALM_PROXY), arbUsdcProxyBalance);
+        assertEq(arbUsdc.balanceOf(Arbitrum.ALM_PROXY), arbUsdcProxyBalance);
 
-        // chainSpellMetadata[ChainIdUtils.Ethereum()].domain.selectFork();
+        chainSpellMetadata[ChainIdUtils.Ethereum()].domain.selectFork();
 
-        // assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
+        assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
 
-        // _relayMessageOverBridges();
+        _relayMessageOverBridges();
 
-        // assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance + usdcAmount);
+        assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance + usdcAmount);
 
-        // // --- Step 5: Swap USDC to USDS and burn ---
+        // --- Step 5: Swap USDC to USDS and burn ---
 
-        // vm.startPrank(Ethereum.ALM_RELAYER);
-        // mainnetController.swapUSDCToUSDS(usdcAmount);
-        // mainnetController.burnUSDS(usdcAmount * 1e12);
-        // vm.stopPrank();
+        vm.startPrank(Ethereum.ALM_RELAYER);
+        mainnetController.swapUSDCToUSDS(usdcAmount);
+        mainnetController.burnUSDS(usdcAmount * 1e12);
+        vm.stopPrank();
 
-        // assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
+        assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
     }
 
     function _testE2ESparkLiquidityLayerBase(
@@ -436,53 +436,53 @@ abstract contract SparkLiquidityLayerTests is SpellRunner {
         console.log("arb bridge 1    ", uint256(chainSpellMetadata[ChainIdUtils.ArbitrumOne()].bridgeTypes[1]));
         console.log("base bridge 0   ", uint256(chainSpellMetadata[ChainIdUtils.Base()].bridgeTypes[0]));
 
-        // _relayMessageOverBridges();
+        _relayMessageOverBridges();
         // CCTPBridgeTesting.relayMessagesToDestination(
         //     chainSpellMetadata[ChainIdUtils.Base()].bridges[1], true
         // );
 
-        // assertEq(baseUsdc.balanceOf(Base.ALM_PROXY), baseUsdcProxyBalance + usdcAmount);
-        // assertEq(baseUsdc.balanceOf(Base.PSM3),      baseUsdcPsmBalance);
+        assertEq(baseUsdc.balanceOf(Base.ALM_PROXY), baseUsdcProxyBalance + usdcAmount);
+        assertEq(baseUsdc.balanceOf(Base.PSM3),      baseUsdcPsmBalance);
 
-        // // --- Step 3: Deposit USDC into PSM3 ---
+        // --- Step 3: Deposit USDC into PSM3 ---
 
-        // vm.prank(Base.ALM_RELAYER);
-        // baseController.depositPSM(Base.USDC, usdcAmount);
+        vm.prank(Base.ALM_RELAYER);
+        baseController.depositPSM(Base.USDC, usdcAmount);
 
-        // assertEq(baseUsdc.balanceOf(Base.ALM_PROXY), baseUsdcProxyBalance);
-        // assertEq(baseUsdc.balanceOf(Base.PSM3),      baseUsdcPsmBalance + usdcAmount);
+        assertEq(baseUsdc.balanceOf(Base.ALM_PROXY), baseUsdcProxyBalance);
+        assertEq(baseUsdc.balanceOf(Base.PSM3),      baseUsdcPsmBalance + usdcAmount);
 
-        // // --- Step 4: Withdraw all assets from PSM3 ---
+        // --- Step 4: Withdraw all assets from PSM3 ---
 
-        // vm.prank(Base.ALM_RELAYER);
-        // baseController.withdrawPSM(Base.USDC, usdcAmount);
+        vm.prank(Base.ALM_RELAYER);
+        baseController.withdrawPSM(Base.USDC, usdcAmount);
 
-        // assertEq(baseUsdc.balanceOf(Base.ALM_PROXY), baseUsdcProxyBalance + usdcAmount);
-        // assertEq(baseUsdc.balanceOf(Base.PSM3),      baseUsdcPsmBalance);
+        assertEq(baseUsdc.balanceOf(Base.ALM_PROXY), baseUsdcProxyBalance + usdcAmount);
+        assertEq(baseUsdc.balanceOf(Base.PSM3),      baseUsdcPsmBalance);
 
-        // // --- Step 5: Bridge USDC back to mainnet ---
+        // --- Step 5: Bridge USDC back to mainnet ---
 
-        // vm.prank(Base.ALM_RELAYER);
-        // baseController.transferUSDCToCCTP(usdcAmount, CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM);
+        vm.prank(Base.ALM_RELAYER);
+        baseController.transferUSDCToCCTP(usdcAmount, CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM);
 
-        // assertEq(baseUsdc.balanceOf(Base.ALM_PROXY), baseUsdcProxyBalance);
+        assertEq(baseUsdc.balanceOf(Base.ALM_PROXY), baseUsdcProxyBalance);
 
-        // chainSpellMetadata[ChainIdUtils.Ethereum()].domain.selectFork();
+        chainSpellMetadata[ChainIdUtils.Ethereum()].domain.selectFork();
 
-        // assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
+        assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
 
-        // _relayMessageOverBridges();
+        _relayMessageOverBridges();
 
-        // assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance + usdcAmount);
+        assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance + usdcAmount);
 
-        // // --- Step 6: Swap USDC to USDS and burn ---
+        // --- Step 6: Swap USDC to USDS and burn ---
 
-        // vm.startPrank(Ethereum.ALM_RELAYER);
-        // mainnetController.swapUSDCToUSDS(usdcAmount);
-        // mainnetController.burnUSDS(usdcAmount * 1e12);
-        // vm.stopPrank();
+        vm.startPrank(Ethereum.ALM_RELAYER);
+        mainnetController.swapUSDCToUSDS(usdcAmount);
+        mainnetController.burnUSDS(usdcAmount * 1e12);
+        vm.stopPrank();
 
-        // assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
+        assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
     }
 
     function _testE2ESLLCrossChainForDomain(
@@ -542,117 +542,117 @@ abstract contract SparkLiquidityLayerTests is SpellRunner {
         _relayMessageOverBridges();
 
         assertEq(domainUsdc.balanceOf(domainAlmProxy), domainUsdcProxyBalance + usdcAmount);
-        // assertEq(domainUsdc.balanceOf(domainPsm3),     domainUsdcPsmBalance);
+        assertEq(domainUsdc.balanceOf(domainPsm3),     domainUsdcPsmBalance);
 
-        // // --- Step 3: Deposit USDC into PSM3 ---
+        // --- Step 3: Deposit USDC into PSM3 ---
 
-        // vm.prank(ctx.relayer);
-        // domainController.depositPSM(address(domainUsdc), usdcAmount);
+        vm.prank(ctx.relayer);
+        domainController.depositPSM(address(domainUsdc), usdcAmount);
 
-        // assertEq(domainUsdc.balanceOf(domainAlmProxy), domainUsdcProxyBalance);
-        // assertEq(domainUsdc.balanceOf(domainPsm3),     domainUsdcPsmBalance + usdcAmount);
+        assertEq(domainUsdc.balanceOf(domainAlmProxy), domainUsdcProxyBalance);
+        assertEq(domainUsdc.balanceOf(domainPsm3),     domainUsdcPsmBalance + usdcAmount);
 
-        // // --- Step 4: Withdraw all assets from PSM3 ---
+        // --- Step 4: Withdraw all assets from PSM3 ---
 
-        // vm.prank(ctx.relayer);
-        // domainController.withdrawPSM(address(domainUsdc), usdcAmount);
+        vm.prank(ctx.relayer);
+        domainController.withdrawPSM(address(domainUsdc), usdcAmount);
 
-        // assertEq(domainUsdc.balanceOf(domainAlmProxy), domainUsdcProxyBalance + usdcAmount);
-        // assertEq(domainUsdc.balanceOf(domainPsm3),     domainUsdcPsmBalance);
+        assertEq(domainUsdc.balanceOf(domainAlmProxy), domainUsdcProxyBalance + usdcAmount);
+        assertEq(domainUsdc.balanceOf(domainPsm3),     domainUsdcPsmBalance);
 
-        // // --- Step 5: Bridge USDC back to mainnet ---
+        // --- Step 5: Bridge USDC back to mainnet ---
 
-        // vm.prank(ctx.relayer);
-        // domainController.transferUSDCToCCTP(usdcAmount, CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM);
+        vm.prank(ctx.relayer);
+        domainController.transferUSDCToCCTP(usdcAmount, CCTPForwarder.DOMAIN_ID_CIRCLE_ETHEREUM);
 
-        // assertEq(domainUsdc.balanceOf(domainAlmProxy), domainUsdcProxyBalance);
+        assertEq(domainUsdc.balanceOf(domainAlmProxy), domainUsdcProxyBalance);
 
-        // chainSpellMetadata[ChainIdUtils.Ethereum()].domain.selectFork();
+        chainSpellMetadata[ChainIdUtils.Ethereum()].domain.selectFork();
 
-        // assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
+        assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
 
-        // _relayMessageOverBridges();
+        _relayMessageOverBridges();
 
-        // assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance + usdcAmount);
+        assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance + usdcAmount);
 
-        // // --- Step 6: Swap USDC to USDS and burn ---
+        // --- Step 6: Swap USDC to USDS and burn ---
 
-        // vm.startPrank(Ethereum.ALM_RELAYER);
-        // mainnetController.swapUSDCToUSDS(usdcAmount);
-        // mainnetController.burnUSDS(usdcAmount * 1e12);
-        // vm.stopPrank();
+        vm.startPrank(Ethereum.ALM_RELAYER);
+        mainnetController.swapUSDCToUSDS(usdcAmount);
+        mainnetController.burnUSDS(usdcAmount * 1e12);
+        vm.stopPrank();
 
-        // assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
+        assertEq(usdc.balanceOf(Ethereum.ALM_PROXY), mainnetUsdcProxyBalance);
     }
 
     /**********************************************************************************************/
     /*** E2E tests to be run on every spell                                                     ***/
     /**********************************************************************************************/
 
-    function test_E2E_sparkLiquidityLayerCrossChainSetup() public{
-        // _testE2ESparkLiquidityLayerArbitrum(
-        //     MainnetController(Ethereum.ALM_CONTROLLER),
-        //     ForeignController(Arbitrum.ALM_CONTROLLER)
-        // );
+    // function test_E2E_sparkLiquidityLayerCrossChainSetup() public{
+    //     _testE2ESparkLiquidityLayerArbitrum(
+    //         MainnetController(Ethereum.ALM_CONTROLLER),
+    //         ForeignController(Arbitrum.ALM_CONTROLLER)
+    //     );
 
-        _testE2ESparkLiquidityLayerBase(
-            MainnetController(Ethereum.ALM_CONTROLLER),
-            ForeignController(Base.ALM_CONTROLLER)
-        );
-
-        // executeAllPayloadsAndBridges();
-
-        // // Load the latest controllers (will return the same values if not overridden)
-        // (
-        //     address updatedMainnetController,
-        //     address updatedArbController,
-        //     address updatedBaseController
-        // ) = _getLatestControllers();
-
-        // _testE2ESparkLiquidityLayerArbitrum(
-        //     MainnetController(updatedMainnetController),
-        //     ForeignController(updatedArbController)
-        // );
-
-        // _testE2ESparkLiquidityLayerBase(
-        //     MainnetController(updatedMainnetController),
-        //     ForeignController(updatedBaseController)
-        // );
-    }
-
-    // function test_E2E_sparkLiquidityLayerCrossChainSetup2() public{
-    //     // _testE2ESLLCrossChainForDomain(
-    //     //     ChainIdUtils.ArbitrumOne(),
-    //     //     MainnetController(Ethereum.ALM_CONTROLLER),
-    //     //     ForeignController(Arbitrum.ALM_CONTROLLER)
-    //     // );
-
-    //     _testE2ESLLCrossChainForDomain(
-    //         ChainIdUtils.Base(),
+    //     _testE2ESparkLiquidityLayerBase(
     //         MainnetController(Ethereum.ALM_CONTROLLER),
     //         ForeignController(Base.ALM_CONTROLLER)
     //     );
 
-    //     // executeAllPayloadsAndBridges();
+    //     executeAllPayloadsAndBridges();
 
-    //     // // Load the latest controllers (will return the same values if not overridden)
-    //     // (
-    //     //     address updatedMainnetController,
-    //     //     address updatedArbController,
-    //     //     address updatedBaseController
-    //     // ) = _getLatestControllers();
+    //     // Load the latest controllers (will return the same values if not overridden)
+    //     (
+    //         address updatedMainnetController,
+    //         address updatedArbController,
+    //         address updatedBaseController
+    //     ) = _getLatestControllers();
 
-    //     // _testE2ESLLCrossChainForDomain(
-    //     //     ChainIdUtils.ArbitrumOne(),
-    //     //     MainnetController(updatedMainnetController),
-    //     //     ForeignController(updatedArbController)
-    //     // );
+    //     _testE2ESparkLiquidityLayerArbitrum(
+    //         MainnetController(updatedMainnetController),
+    //         ForeignController(updatedArbController)
+    //     );
 
-    //     // _testE2ESLLCrossChainForDomain(
-    //     //     ChainIdUtils.Base(),
-    //     //     MainnetController(updatedMainnetController),
-    //     //     ForeignController(updatedBaseController)
-    //     // );
+    //     _testE2ESparkLiquidityLayerBase(
+    //         MainnetController(updatedMainnetController),
+    //         ForeignController(updatedBaseController)
+    //     );
     // }
+
+    function test_E2E_sparkLiquidityLayerCrossChainSetup() public{
+        _testE2ESLLCrossChainForDomain(
+            ChainIdUtils.ArbitrumOne(),
+            MainnetController(Ethereum.ALM_CONTROLLER),
+            ForeignController(Arbitrum.ALM_CONTROLLER)
+        );
+
+        _testE2ESLLCrossChainForDomain(
+            ChainIdUtils.Base(),
+            MainnetController(Ethereum.ALM_CONTROLLER),
+            ForeignController(Base.ALM_CONTROLLER)
+        );
+
+        executeAllPayloadsAndBridges();
+
+        // Load the latest controllers (will return the same values if not overridden)
+        (
+            address updatedMainnetController,
+            address updatedArbController,
+            address updatedBaseController
+        ) = _getLatestControllers();
+
+        _testE2ESLLCrossChainForDomain(
+            ChainIdUtils.ArbitrumOne(),
+            MainnetController(updatedMainnetController),
+            ForeignController(updatedArbController)
+        );
+
+        _testE2ESLLCrossChainForDomain(
+            ChainIdUtils.Base(),
+            MainnetController(updatedMainnetController),
+            ForeignController(updatedBaseController)
+        );
+    }
 
 }

--- a/src/test-harness/SpellRunner.sol
+++ b/src/test-harness/SpellRunner.sol
@@ -76,8 +76,6 @@ abstract contract SpellRunner is Test {
         chainSpellMetadata[ChainIdUtils.Gnosis()].executor      = IExecutor(Gnosis.AMB_EXECUTOR);
         chainSpellMetadata[ChainIdUtils.ArbitrumOne()].executor = IExecutor(Arbitrum.SPARK_EXECUTOR);
 
-        console.log("--- setupDomains");
-
         // Arbitrum One
         chainSpellMetadata[ChainIdUtils.ArbitrumOne()].bridges.push(
             ArbitrumBridgeTesting.createNativeBridge(
@@ -121,12 +119,9 @@ abstract contract SpellRunner is Test {
         allChains.push(ChainIdUtils.Base());
         allChains.push(ChainIdUtils.Gnosis());
         allChains.push(ChainIdUtils.ArbitrumOne());
-
-        console.log("arb num bridges ", chainSpellMetadata[ChainIdUtils.ArbitrumOne()].bridges.length);
-        console.log("base num bridges", chainSpellMetadata[ChainIdUtils.Base()].bridges.length);
     }
 
-    function spellIdentifier(ChainId chainId) private view returns(string memory){
+    function spellIdentifier(ChainId chainId) private view returns(string memory) {
         string memory slug            = string(abi.encodePacked("Spark", chainId.toDomainString(), "_", id));
         string memory identifier = string(abi.encodePacked(slug, ".sol:", slug));
         return identifier;
@@ -227,7 +222,7 @@ abstract contract SpellRunner is Test {
         }
     }
 
-    function executeMainnetPayload() internal onChain(ChainIdUtils.Ethereum()){
+    function executeMainnetPayload() internal onChain(ChainIdUtils.Ethereum()) {
         address payloadAddress = chainSpellMetadata[ChainIdUtils.Ethereum()].payload;
         IExecutor executor     = chainSpellMetadata[ChainIdUtils.Ethereum()].executor;
         require(Address.isContract(payloadAddress), "PAYLOAD IS NOT A CONTRACT");

--- a/src/test-harness/SpellRunner.sol
+++ b/src/test-harness/SpellRunner.sol
@@ -38,7 +38,7 @@ abstract contract SpellRunner is Test {
         ARBITRUM
     }
 
-    struct ChainSpellMetadata{
+    struct ChainSpellMetadata {
       address                        payload;
       IExecutor                      executor;
       Domain                         domain;
@@ -75,6 +75,8 @@ abstract contract SpellRunner is Test {
         chainSpellMetadata[ChainIdUtils.Base()].executor        = IExecutor(Base.SPARK_EXECUTOR);
         chainSpellMetadata[ChainIdUtils.Gnosis()].executor      = IExecutor(Gnosis.AMB_EXECUTOR);
         chainSpellMetadata[ChainIdUtils.ArbitrumOne()].executor = IExecutor(Arbitrum.SPARK_EXECUTOR);
+
+        console.log("--- setupDomains");
 
         // Arbitrum One
         chainSpellMetadata[ChainIdUtils.ArbitrumOne()].bridges.push(
@@ -119,6 +121,9 @@ abstract contract SpellRunner is Test {
         allChains.push(ChainIdUtils.Base());
         allChains.push(ChainIdUtils.Gnosis());
         allChains.push(ChainIdUtils.ArbitrumOne());
+
+        console.log("arb num bridges ", chainSpellMetadata[ChainIdUtils.ArbitrumOne()].bridges.length);
+        console.log("base num bridges", chainSpellMetadata[ChainIdUtils.Base()].bridges.length);
     }
 
     function spellIdentifier(ChainId chainId) private view returns(string memory){


### PR DESCRIPTION
Adds coverage for Mainnet -> Arbitrum -> Mainnet -> Base -> Mainnet CCTP transfers in an e2e test.

NOTE: Still having issues with `Nonce already used` when using 10m, tracked in a TODO.